### PR TITLE
0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Knave Second Edition for FoundryVTT is still in a beta stage, and is likely to h
 This system would not have been possible without the following people:
 1. Ben Milton and Questing Beast LLC. Thank you for a fantastic follow-up to Knave First Edition, and thank you for the permission to distribute this system to other fans!
 
-2. The FoundryVTT Boilerplate System developer `asacolips`, who is responsible for indirectly birthing more FoundryVTT game systems than anyone.
+2. The FoundryVTT Boilerplate System developer [asacolips](https://github.com/asacolips), who is responsible for indirectly birthing more FoundryVTT game systems than anyone.
 
-3. `mxzf`, `chaosOS`, `Ethaks`, `Draft`, and the rest of the incredible FoundryVTT development gurus in the FoundryVTT Discord server. Partially for their wisdom, but mostly for their patience.
+3. [mxzf](https://gitlab.com/mxzf), [chaosOS](https://github.com/JPMeehan), [Ethaks](https://github.com/Ethaks), `Draft`, and the rest of the incredible FoundryVTT development gurus in the FoundryVTT Discord server. Partially for their wisdom, but mostly for their patience.
 
 

--- a/module/data/character.mjs
+++ b/module/data/character.mjs
@@ -300,3 +300,5 @@ export default class Knave2eCharacter extends Knave2eActorType {
         }
     }
 }
+
+

--- a/module/data/character.mjs
+++ b/module/data/character.mjs
@@ -100,13 +100,30 @@ export default class Knave2eCharacter extends Knave2eActorType {
     prepareBaseData() {}
 
     prepareDerivedData() {
+        this._deriveBlessings();
+        this._deriveCompanions();
         this._deriveHP();
         this._deriveLevel();
         this._deriveSlots();
+        this._deriveSpells();
+    }
+
+    _deriveBlessings() {
+        if (game.settings.get('knave2e', 'automaticBlessings')) {
+            this.blessings.max = this.abilities.charisma.value;
+        }
+    }
+
+    _deriveCompanions() {
+        if (game.settings.get('knave2e', 'automaticCompanions')) {
+            this.companions.max = this.abilities.charisma.value;
+        }
     }
 
     _deriveHP() {
-        //Cap current HP/wounds to max HP/wounds
+        if (game.settings.get('knave2e', 'automaticWounds')) {
+            this.wounds.max = 10 + this.abilities.constitution.value;
+        }
         this.hitPoints.value = Math.min(this.hitPoints.value, this.hitPoints.max);
         this.wounds.value = Math.min(this.wounds.value, this.wounds.max);
 
@@ -191,6 +208,12 @@ export default class Knave2eCharacter extends Knave2eActorType {
 
         if (usedSlots > this.slots.max) {
             this.deriveDroppedItems(usedSlots - this.slots.max);
+        }
+    }
+
+    _deriveSpells() {
+        if (game.settings.get('knave2e', 'automaticSpells')) {
+            this.spells.max = this.abilities.intelligence.value;
         }
     }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -30,22 +30,6 @@ export default class Knave2eActor extends Actor {
     if (actorData.type !== "character") return;
 
     const systemData = actorData.system;
-
-    if (game.settings.get("knave2e", "automaticBlessings")) {
-      systemData.blessings.max = systemData.abilities.charisma.value;
-    }
-
-    if (game.settings.get("knave2e", "automaticCompanions")) {
-      systemData.companions.max = systemData.abilities.charisma.value;
-    }
-
-    if (game.settings.get("knave2e", "automaticSpells")) {
-      systemData.spells.max = systemData.abilities.intelligence.value;
-    }
-
-    if (game.settings.get("knave2e", "automaticWounds")) {
-      systemData.wounds.max = 10 + systemData.abilities.constitution.value;
-    }
   }
 
   _prepareRecruitData(actorData) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,108 +1,138 @@
 export default class Knave2eActor extends Actor {
-  async _preCreate(data) {
-    if ((await super._preCreate(data)) === false) return false;
-    if (data.type === "character" || data.type === "recruit") {
-      this.updateSource({ "prototypeToken.actorLink": true });
-    }
-    if (data.type === "character") {
-      if (game.settings.get("knave2e", "automaticVision")) {
-        this.updateSource({ "prototypeToken.sight.enabled": true });
-      }
-    }
-  }
-
-  prepareData() {
-    super.prepareData();
-  }
-
-  prepareBaseData() {}
-
-  prepareDerivedData() {
-    const actorData = this;
-    // const systemData = actorData.system;
-    // const flags = actorData.flags.knave2e || {};
-
-    this._prepareCharacterData(actorData);
-    this._prepareRecruitData(actorData);
-  }
-
-  _prepareCharacterData(actorData) {
-    if (actorData.type !== "character") return;
-
-    const systemData = actorData.system;
-  }
-
-  _prepareRecruitData(actorData) {
-    if (actorData.type !== "recruit") return;
-
-    const systemData = actorData.system;
-
-    if (game.settings.get("knave2e", "automaticRecruits")) {
-      if (
-        actorData.system.category == "expert" &&
-        actorData.system.rarity == "KNAVE2E.Rare"
-      ) {
-        systemData.spells.max = 1;
-      } else {
-        systemData.spells.max = 0;
-      }
-    }
-  }
-
-  _prepareVehicleData(actorData) {
-    if (actorData.type !== "vehicle") return;
-
-    const systemData = actorData.system;
-  }
-
-  _prepareMonsterData(actorData) {
-    if (actorData.type !== "monster") return;
-
-    const systemData = actorData.system;
-  }
-
-  /**
-   * Override getRollData() that's supplied to rolls.
-   */
-  getRollData() {
-    const data = super.getRollData();
-
-    // Prepare character roll data.
-    this._getCharacterRollData(data);
-    this._getRecruitRollData(data);
-    this._getMonsterRollData(data);
-    this._getVehicleRollData(data);
-
-    return data;
-  }
-
-  _getCharacterRollData(data) {
-    if (this.type !== "character") return;
-
-    // Copy the ability score values to the top level, so that rolls can use formulas like `d20 + @strength`.
-    for (let [k, v] of Object.entries(data.abilities)) {
-      data[k] = foundry.utils.deepClone(v).value;
+    async _preCreate(data) {
+        if ((await super._preCreate(data)) === false) return false;
+        if (data.type === 'character' || data.type === 'recruit') {
+            this.updateSource({ 'prototypeToken.actorLink': true });
+        }
+        if (data.type === 'character') {
+            if (game.settings.get('knave2e', 'automaticVision')) {
+                this.updateSource({ 'prototypeToken.sight.enabled': true });
+            }
+        }
     }
 
-    data.speaker = ChatMessage.getSpeaker({ actor: this });
-    data.rollMode = game.settings.get("core", "rollMode");
-  }
+    prepareData() {
+        super.prepareData();
+    }
 
-  _getRecruitRollData(data) {
-    if (this.type !== "recruit") return;
+    prepareBaseData() {}
 
-    // Process additional Recruit data here.
-  }
+    prepareDerivedData() {
+        const actorData = this;
+        // const systemData = actorData.system;
+        // const flags = actorData.flags.knave2e || {};
 
-  _getMonsterRollData(data) {
-    if (this.type !== "monster") return;
+        this._prepareCharacterData(actorData);
+        this._prepareRecruitData(actorData);
+    }
 
-    // Process additional Monster data here.
-  }
+    async modifyTokenAttribute(attribute, value, isDelta = false, isBar = true) {
+        if (attribute !== 'hitPoints' || this.type !== 'character' || isDelta === false || value >= 0) {
+            return await super.modifyTokenAttribute(attribute, value, isDelta, isBar);
+        }
 
-  _getVehicleRollData(data) {
-    if (this.type !== "vehicle") return;
+        // Characters take damage differently than recruits/monsters, since they have wounds
+        const attr = foundry.utils.getProperty(this.system, attribute);
+        const current = isBar ? attr.value : attr;
+        const update = isDelta ? current + value : value;
+        if (update === current) return this;
 
-    // Process additional Vehicle data here.
-  }
+        // Determine the HP overflow into wounds
+        let updates;
+        if (isBar) updates = { [`system.${attribute}.value`]: Math.clamp(update, 0, attr.max) };
+        else updates = { [`system.${attribute}`]: update };
+
+        if (update <= 0) {
+            const wounds = this.system.wounds
+            if (isBar) updates = {
+                ...updates,
+                [`system.wounds.value`]: Math.clamp(wounds.value - Math.abs(update), 0, wounds.max),
+            };
+            else updates = {
+                ...updates,
+                [`system.wounds`]: Math.clamp(wounds.value - Math.abs(update), 0, wounds.max)
+            }
+        }
+
+        // Allow a hook to override these changes
+        const allowed = Hooks.call('modifyTokenAttribute', { attribute, value, isDelta, isBar }, updates);
+        return allowed !== false ? this.update(updates) : this;
+    }
+
+    _prepareCharacterData(actorData) {
+        if (actorData.type !== 'character') return;
+
+        const systemData = actorData.system;
+    }
+
+    _prepareRecruitData(actorData) {
+        if (actorData.type !== 'recruit') return;
+
+        const systemData = actorData.system;
+
+        if (game.settings.get('knave2e', 'automaticRecruits')) {
+            if (actorData.system.category == 'expert' && actorData.system.rarity == 'KNAVE2E.Rare') {
+                systemData.spells.max = 1;
+            } else {
+                systemData.spells.max = 0;
+            }
+        }
+    }
+
+    _prepareVehicleData(actorData) {
+        if (actorData.type !== 'vehicle') return;
+
+        const systemData = actorData.system;
+    }
+
+    _prepareMonsterData(actorData) {
+        if (actorData.type !== 'monster') return;
+
+        const systemData = actorData.system;
+    }
+
+    /**
+     * Override getRollData() that's supplied to rolls.
+     */
+    getRollData() {
+        const data = super.getRollData();
+
+        // Prepare character roll data.
+        this._getCharacterRollData(data);
+        this._getRecruitRollData(data);
+        this._getMonsterRollData(data);
+        this._getVehicleRollData(data);
+
+        return data;
+    }
+
+    _getCharacterRollData(data) {
+        if (this.type !== 'character') return;
+
+        // Copy the ability score values to the top level, so that rolls can use formulas like `d20 + @strength`.
+        for (let [k, v] of Object.entries(data.abilities)) {
+            data[k] = foundry.utils.deepClone(v).value;
+        }
+
+        data.speaker = ChatMessage.getSpeaker({ actor: this });
+        data.rollMode = game.settings.get('core', 'rollMode');
+    }
+
+    _getRecruitRollData(data) {
+        if (this.type !== 'recruit') return;
+
+        // Process additional Recruit data here.
+    }
+
+    _getMonsterRollData(data) {
+        if (this.type !== 'monster') return;
+
+        // Process additional Monster data here.
+    }
+
+    _getVehicleRollData(data) {
+        if (this.type !== 'vehicle') return;
+
+        // Process additional Vehicle data here.
+    }
 }

--- a/module/helpers/items.mjs
+++ b/module/helpers/items.mjs
@@ -1,493 +1,438 @@
 export async function checkDialog(data) {
-  let attackBonus = await Dialog.wait({
-    title: "Check",
-    content: `${game.i18n.localize(
-      "KNAVE2E.CheckDialog"
-    )}<br>${game.i18n.localize("KNAVE2E.SkipDialog")}<br>`,
-    buttons: {
-      standard: {
-        label: `${game.i18n.localize("KNAVE2E.Level")} (${data.level})`,
-        callback: () => {
-          return data.level;
+    let attackBonus = await Dialog.wait({
+        title: 'Check',
+        content: `${game.i18n.localize('KNAVE2E.CheckDialog')}<br>${game.i18n.localize('KNAVE2E.SkipDialog')}<br>`,
+        buttons: {
+            standard: {
+                label: `${game.i18n.localize('KNAVE2E.Level')} (${data.level})`,
+                callback: () => {
+                    return data.level;
+                },
+            },
+            half: {
+                label: `${game.i18n.localize('KNAVE2E.HalfLevel')} (${Math.floor(data.level / 2)})`,
+                callback: () => {
+                    return Math.floor(data.level / 2);
+                },
+            },
+            zero: {
+                label: game.i18n.localize('KNAVE2E.None'),
+                callback: () => {
+                    return '';
+                },
+            },
         },
-      },
-      half: {
-        label: `${game.i18n.localize("KNAVE2E.HalfLevel")} (${Math.floor(
-          data.level / 2
-        )})`,
-        callback: () => {
-          return Math.floor(data.level / 2);
-        },
-      },
-      zero: {
-        label: game.i18n.localize("KNAVE2E.None"),
-        callback: () => {
-          return "";
-        },
-      },
-    },
-    default: "standard",
-  });
+        default: 'standard',
+    });
 
-  return attackBonus;
+    return attackBonus;
 }
 
 export async function damageDialog() {
-  let powerAttack = await Dialog.wait({
-    title: `${game.i18n.localize("KNAVE2E.Damage")}`,
-    content: `${game.i18n.localize(
-      "KNAVE2E.DamageDialog"
-    )}<br/>${game.i18n.localize("KNAVE2E.SkipDialog")}<br/>`,
-    buttons: {
-      standard: {
-        label: game.i18n.localize("KNAVE2E.Standard"),
-        callback: async () => {
-          return false;
+    let powerAttack = await Dialog.wait({
+        title: `${game.i18n.localize('KNAVE2E.Damage')}`,
+        content: `${game.i18n.localize('KNAVE2E.DamageDialog')}<br/>${game.i18n.localize('KNAVE2E.SkipDialog')}<br/>`,
+        buttons: {
+            standard: {
+                label: game.i18n.localize('KNAVE2E.Standard'),
+                callback: async () => {
+                    return false;
+                },
+            },
+            power: {
+                label: game.i18n.localize('KNAVE2E.PowerAttack'),
+                callback: async () => {
+                    return true;
+                },
+            },
         },
-      },
-      power: {
-        label: game.i18n.localize("KNAVE2E.PowerAttack"),
-        callback: async () => {
-          return true;
-        },
-      },
-    },
-    default: "standard",
-  });
+        default: 'standard',
+    });
 
-  return powerAttack;
+    return powerAttack;
 }
 
 export async function onCast(event) {
-  event.preventDefault();
-  const a = event.currentTarget;
+    event.preventDefault();
+    const a = event.currentTarget;
 
-  const li = a.closest("li");
-  const item = li.dataset.itemId
-    ? this.actor.items.get(li.dataset.itemId)
-    : null;
-  const itemData = item.system;
-  const systemData = this.actor.system;
+    const li = a.closest('li');
+    const item = li.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
+    const itemData = item.system;
+    const systemData = this.actor.system;
 
-  if (game.settings.get("knave2e", "automaticSpells")) {
-    // Reminder if actor cannot cast spells
-    if (systemData.spells.max <= 0) {
-      Dialog.prompt({
-        title: `${game.i18n.localize("KNAVE2E.CastDialogTitle")}`,
-        content: `${this.actor.name} ${game.i18n.localize(
-          "KNAVE2E.CastDialogContentMax"
-        )}`,
-        label: "OK",
-        callback: (html) => {
-          return;
-        },
-      });
-      return;
-    } else if (systemData.spells.value >= systemData.spells.max) {
-      Dialog.prompt({
-        title: `${game.i18n.localize("KNAVE2E.CastDialogTitle")}`,
-        content: `${this.actor.name} ${game.i18n.localize(
-          "KNAVE2E.CastDialogContentValue"
-        )}`,
-        label: "OK",
-        callback: (html) => {
-          return;
-        },
-      });
-      return;
-    } else if (itemData.cast === true) {
-      Dialog.prompt({
-        title: `${game.i18n.localize("KNAVE2E.CastDialogTitle")}`,
-        content: `${this.actor.name} ${game.i18n.localize(
-          "KNAVE2E.CastDialogContentUsed"
-        )}`,
-        label: "OK",
-        callback: (html) => {
-          return;
-        },
-      });
-      return;
-    } else {
-      ChatMessage.create({
-        speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-        // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
-        content: `<br><h3>${item.name}</h3>${itemData.description}`,
-        rollMode: game.settings.get("core", "rollMode"),
-      });
-
-      // Cast spell and increment actor's used spells
-      if (game.settings.get("knave2e", "enforceSpells")) {
-        item.update({
-          "system.cast": true,
-        });
-      }
-      this.actor.update({
-        "system.spells.value": systemData.spells.value + 1,
-      });
-    }
-  } else {
-    if (game.settings.get("knave2e", "enforceSpells")) {
-      if (itemData.cast === true) {
-        Dialog.prompt({
-          title: `${game.i18n.localize("KNAVE2E.CastDialogTitle")}`,
-          content: `${this.actor.name} ${game.i18n.localize(
-            "KNAVE2E.CastDialogContentUsed"
-          )}`,
-          label: "OK",
-          callback: (html) => {
+    if (game.settings.get('knave2e', 'automaticSpells')) {
+        // Reminder if actor cannot cast spells
+        if (systemData.spells.max <= 0) {
+            Dialog.prompt({
+                title: `${game.i18n.localize('KNAVE2E.CastDialogTitle')}`,
+                content: `${this.actor.name} ${game.i18n.localize('KNAVE2E.CastDialogContentMax')}`,
+                label: 'OK',
+                callback: (html) => {
+                    return;
+                },
+            });
             return;
-          },
-        });
-        return;
-      } else {
-        ChatMessage.create({
-          speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-          // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
-          content: `<br><h3>${item.name}</h3>${itemData.description}`,
-          rollMode: game.settings.get("core", "rollMode"),
-        });
+        } else if (systemData.spells.value >= systemData.spells.max) {
+            Dialog.prompt({
+                title: `${game.i18n.localize('KNAVE2E.CastDialogTitle')}`,
+                content: `${this.actor.name} ${game.i18n.localize('KNAVE2E.CastDialogContentValue')}`,
+                label: 'OK',
+                callback: (html) => {
+                    return;
+                },
+            });
+            return;
+        } else if (itemData.cast === true) {
+            Dialog.prompt({
+                title: `${game.i18n.localize('KNAVE2E.CastDialogTitle')}`,
+                content: `${this.actor.name} ${game.i18n.localize('KNAVE2E.CastDialogContentUsed')}`,
+                label: 'OK',
+                callback: (html) => {
+                    return;
+                },
+            });
+            return;
+        } else {
+            ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
+                content: `<br><h3>${item.name}</h3>${itemData.description}`,
+                rollMode: game.settings.get('core', 'rollMode'),
+            });
 
-        item.update({
-          "system.cast": true,
-        });
-
-        this.actor.update({
-          "system.spells.value": systemData.spells.value + 1,
-        });
-      }
+            // Cast spell and increment actor's used spells
+            if (game.settings.get('knave2e', 'enforceSpells')) {
+                item.update({
+                    'system.cast': true,
+                });
+            }
+            this.actor.update({
+                'system.spells.value': systemData.spells.value + 1,
+            });
+        }
     } else {
-      ChatMessage.create({
-        speaker: ChatMessage.getSpeaker({ actor: this.actor }),
-        // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
-        content: `<br><h3>${item.name}</h3>${itemData.description}`,
-        rollMode: game.settings.get("core", "rollMode"),
-      });
+        if (game.settings.get('knave2e', 'enforceSpells')) {
+            if (itemData.cast === true) {
+                Dialog.prompt({
+                    title: `${game.i18n.localize('KNAVE2E.CastDialogTitle')}`,
+                    content: `${this.actor.name} ${game.i18n.localize('KNAVE2E.CastDialogContentUsed')}`,
+                    label: 'OK',
+                    callback: (html) => {
+                        return;
+                    },
+                });
+                return;
+            } else {
+                ChatMessage.create({
+                    speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                    // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
+                    content: `<br><h3>${item.name}</h3>${itemData.description}`,
+                    rollMode: game.settings.get('core', 'rollMode'),
+                });
 
-      this.actor.update({
-        "system.spells.value": systemData.spells.value + 1,
-      });
+                item.update({
+                    'system.cast': true,
+                });
+
+                this.actor.update({
+                    'system.spells.value': systemData.spells.value + 1,
+                });
+            }
+        } else {
+            ChatMessage.create({
+                speaker: ChatMessage.getSpeaker({ actor: this.actor }),
+                // flavor: `${this.actor.name} ${game.i18n.localize("KNAVE2E.Casts")}`,
+                content: `<br><h3>${item.name}</h3>${itemData.description}`,
+                rollMode: game.settings.get('core', 'rollMode'),
+            });
+
+            this.actor.update({
+                'system.spells.value': systemData.spells.value + 1,
+            });
+        }
     }
-  }
 }
 
 export async function onAttack(event) {
-  event.preventDefault();
-  const a = event.currentTarget;
+    event.preventDefault();
+    const a = event.currentTarget;
 
-  const li = a.closest("li");
-  const item = li.dataset.itemId
-    ? this.actor.items.get(li.dataset.itemId)
-    : null;
-  const itemData = item.system;
-  const hasDescription = itemData.description === "" ? false : true;
-  const systemData = this.actor.system;
+    const li = a.closest('li');
+    const item = li.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
+    const itemData = item.system;
+    const hasDescription = itemData.description === '' ? false : true;
+    const systemData = this.actor.system;
 
-  // Return if the weapon is broken
-  if (
-    item.type === "weapon" &&
-    itemData.broken === true &&
-    game.settings.get("knave2e", "enforceBreaks")
-  ) {
-    Dialog.prompt({
-      title: `${game.i18n.localize("KNAVE2E.Item")} ${game.i18n.localize(
-        "KNAVE2E.Broken"
-      )}`,
-      content: `${item.name} ${game.i18n.localize("KNAVE2E.IsBroken")}!`,
-      label: "OK",
-      callback: (html) => {
+    // Return if the weapon is broken
+    if (item.type === 'weapon' && itemData.broken === true && game.settings.get('knave2e', 'enforceBreaks')) {
+        Dialog.prompt({
+            title: `${game.i18n.localize('KNAVE2E.Item')} ${game.i18n.localize('KNAVE2E.Broken')}`,
+            content: `${item.name} ${game.i18n.localize('KNAVE2E.IsBroken')}!`,
+            label: 'OK',
+            callback: (html) => {
+                return;
+            },
+        });
+
         return;
-      },
-    });
+    }
 
-    return;
-  }
+    const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+    const rollMode = game.settings.get('core', 'rollMode');
+    let flavor = `${game.i18n.localize('KNAVE2E.AttackRoll')} ${game.i18n.localize('KNAVE2E.With')} ${item.name}`;
 
-  const speaker = ChatMessage.getSpeaker({ actor: this.actor });
-  const rollMode = game.settings.get("core", "rollMode");
-  let flavor = `${game.i18n.localize(
-    "KNAVE2E.AttackRoll"
-  )} ${game.i18n.localize("KNAVE2E.With")} ${item.name}`;
+    // Override base roll function to deliver to ChatMessage
+    let messageData = {
+        from: game.user._id,
+        sound: 'sounds/dice.wav',
+        speaker: speaker,
+        rollMode: rollMode,
+        rolls: [],
+    };
 
-  // Override base roll function to deliver to ChatMessage
-  let messageData = {
-    from: game.user._id,
-    sound: "sounds/dice.wav",
-    speaker: speaker,
-    rollMode: rollMode,
-    rolls: []
-  };
+    // Pass item info for clickable Damage & Direct buttons in-chat. Will update item/buttons/flavor in-method
+    const rollData = {
+        data: {
+            item: item._id,
+            actor: this.actor._id,
+            buttons: true,
+            character: true,
+            description: itemData.description,
+            hasDescription: hasDescription,
+        },
+        flavor: flavor,
+        rolls: [],
+    };
 
-  // Pass item info for clickable Damage & Direct buttons in-chat. Will update item/buttons/flavor in-method
-  const rollData = {
-    data: {
-      item: item._id,
-      actor: this.actor._id,
-      buttons: true,
-      character: true,
-      description: itemData.description,
-      hasDescription: hasDescription,
-    },
-    flavor: flavor,
-    rolls: [],
-  };
+    // Return early if a ranged weapon is out of ammo
+    if (!hasAmmo(item, this.actor) && game.settings.get('knave2e', 'enforceAmmo')) {
+        Dialog.prompt({
+            title: `${game.i18n.localize('KNAVE2E.OutOfAmmoTitleDialog')}`,
+            content: `${this.actor.name} ${game.i18n.localize('KNAVE2E.OutOfAmmoContentDialog')} ${item.name}!`,
+            label: 'OK',
+            callback: (html) => {
+                return;
+            },
+        });
 
-  // Return early if a ranged weapon is out of ammo
-  if (
-    !hasAmmo(item, this.actor) &&
-    game.settings.get("knave2e", "enforceAmmo")
-  ) {
-    Dialog.prompt({
-      title: `${game.i18n.localize("KNAVE2E.OutOfAmmoTitleDialog")}`,
-      content: `${this.actor.name} ${game.i18n.localize(
-        "KNAVE2E.OutOfAmmoContentDialog"
-      )} ${item.name}!`,
-      label: "OK",
-      callback: (html) => {
         return;
-      },
-    });
-
-    return;
-  }
-
-  // Build the roll formula piecemeal
-  const die = "1d20";
-  let attackRollFormula;
-  let attackRollBonus;
-
-  /* -------------------------------------------- */
-  /*  Attack Bonus                                */
-  /* -------------------------------------------- */
-
-  // Roll with level for recruits & monsters
-  if (this.actor.type !== "character") {
-    // Skip dialog window on shift + click, default to system level
-    if (event.shiftKey === true) {
-      attackRollBonus = systemData.level;
-    } else {
-      // get attack roll bonus from options
-      attackRollBonus = await checkDialog(systemData);
-    }
-  }
-
-  // Roll with abilities for characters
-  else {
-    attackRollBonus =
-      itemData.category === "melee"
-        ? systemData.abilities.strength.value.toString()
-        : systemData.abilities.wisdom.value.toString();
-  }
-
-  if (item.type === "weapon" || item.type === "monsterAttack") {
-    attackRollBonus += (item.system.attackBonus ?? 0)
-  }
-  
-
-  /* -------------------------------------------- */
-  /*  Attack Formula                              */
-  /* -------------------------------------------- */
-
-  // Evaluate a roll and determine post-roll effects
-  attackRollFormula = `${die} + ${attackRollBonus}`;
-
-  let r = new Roll(attackRollFormula, { data: rollData });
-  await r.evaluate();
-
-  // Weapons from characters or recruits can break
-  if (item.type === "weapon") {
-    if (game.settings.get("knave2e", "enforceBreaks")) {
-      // Check for weapon break on natural 1
-      if (r.terms[0].results[0].result === 1) {
-        rollData.flavor = `${item.name} ${game.i18n.localize(
-          "KNAVE2E.Breaks"
-        )}!`;
-
-        item.update({
-          "system.broken": true,
-        });
-
-        // Turn off buttons for broken weapons
-        rollData.data.buttons = false;
-      }
-    }
-  }
-
-  // Attack from characters get free maneuvers
-  if (this.actor.type === "character") {
-    if (r.total >= 21) {
-      rollData.flavor = `${this.actor.name} ${game.i18n.localize(
-        "KNAVE2E.ManeuverSuccess"
-      )}`;
-    }
-  }
-
-  // Remove direct damage button option for monsters
-  else if (this.actor.type === "monster") {
-    rollData.data.character = false;
-  }
-
-  /* -------------------------------------------- */
-  /*  Attack Roll                                 */
-  /* -------------------------------------------- */
-
-  // Push roll to rolls[] array for Dice So Nice
-  r.toolTip = await r.getTooltip();
-  rollData.rolls.push(r);
-
-  // Merge and push to chat message
-  //messageData = foundry.utils.mergeObject(messageData, rollData);
-  messageData.content = await renderTemplate(
-    "systems/knave2e/templates/item/item-chat-message.hbs",
-    rollData
-  );
-  ChatMessage.create(messageData);
-  // Check for ammo and decrement ammo counter
-  function hasAmmo(item, actor) {
-    const systemData = actor.system;
-
-    // Reject monster and melee weapon attacks
-    if (actor.type == "monster" || item.type !== "weapon" || item.system.category !== "ranged") {
-      return true;
     }
 
-    const ammoType = item.system.ammoType;
+    // Build the roll formula piecemeal
+    const die = '1d20';
+    let attackRollFormula;
+    let attackRollBonus;
 
-    if (game.settings.get("knave2e", "enforceAmmo")) {
-      if (ammoType === "arrow" && systemData.ammo[ammoType] >= 1) {
-        actor.update({
-          "system.ammo.arrow": systemData.ammo.arrow - 1,
-        });
-        return true;
-      } else if (ammoType === "bullet" && systemData.ammo[ammoType] >= 1) {
-        actor.update({
-          "system.ammo.bullet": systemData.ammo.bullet - 1,
-        });
-        return true;
-      } else if (ammoType === "none") {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return true;
+    /* -------------------------------------------- */
+    /*  Attack Bonus                                */
+    /* -------------------------------------------- */
+
+    // Roll with level for recruits & monsters
+    if (this.actor.type !== 'character') {
+        // Skip dialog window on shift + click, default to system level
+        if (event.shiftKey === true) {
+            attackRollBonus = systemData.level;
+        } else {
+            // get attack roll bonus from options
+            attackRollBonus = await checkDialog(systemData);
+        }
     }
-  }
+
+    // Roll with abilities for characters
+    else {
+        attackRollBonus =
+            itemData.category === 'melee' ? systemData.abilities.strength.value : systemData.abilities.wisdom.value;
+    }
+
+    if (item.type === 'weapon' || item.type === 'monsterAttack') {
+        attackRollBonus += item.system.attackBonus ?? 0;
+    }
+
+    /* -------------------------------------------- */
+    /*  Attack Formula                              */
+    /* -------------------------------------------- */
+
+    // Evaluate a roll and determine post-roll effects
+    attackRollFormula = `${die} + ${attackRollBonus}`;
+
+    let r = new Roll(attackRollFormula, { data: rollData });
+    await r.evaluate();
+
+    // Weapons from characters or recruits can break
+    if (item.type === 'weapon') {
+        if (game.settings.get('knave2e', 'enforceBreaks')) {
+            // Check for weapon break on natural 1
+            if (r.terms[0].results[0].result === 1) {
+                rollData.flavor = `${item.name} ${game.i18n.localize('KNAVE2E.Breaks')}!`;
+
+                item.update({
+                    'system.broken': true,
+                });
+
+                // Turn off buttons for broken weapons
+                rollData.data.buttons = false;
+            }
+        }
+    }
+
+    // Attack from characters get free maneuvers
+    if (this.actor.type === 'character') {
+        if (r.total >= 21) {
+            rollData.flavor = `${this.actor.name} ${game.i18n.localize('KNAVE2E.ManeuverSuccess')}`;
+        }
+    }
+
+    // Remove direct damage button option for monsters
+    else if (this.actor.type === 'monster') {
+        rollData.data.character = false;
+    }
+
+    /* -------------------------------------------- */
+    /*  Attack Roll                                 */
+    /* -------------------------------------------- */
+
+    // Push roll to rolls[] array for Dice So Nice
+    r.toolTip = await r.getTooltip();
+    rollData.rolls.push(r);
+
+    // Merge and push to chat message
+    //messageData = foundry.utils.mergeObject(messageData, rollData);
+    messageData.content = await renderTemplate('systems/knave2e/templates/item/item-chat-message.hbs', rollData);
+    ChatMessage.create(messageData);
+    // Check for ammo and decrement ammo counter
+    function hasAmmo(item, actor) {
+        const systemData = actor.system;
+
+        // Reject monster and melee weapon attacks
+        if (actor.type == 'monster' || item.type !== 'weapon' || item.system.category !== 'ranged') {
+            return true;
+        }
+
+        const ammoType = item.system.ammoType;
+
+        if (game.settings.get('knave2e', 'enforceAmmo')) {
+            if (ammoType === 'arrow' && systemData.ammo[ammoType] >= 1) {
+                actor.update({
+                    'system.ammo.arrow': systemData.ammo.arrow - 1,
+                });
+                return true;
+            } else if (ammoType === 'bullet' && systemData.ammo[ammoType] >= 1) {
+                actor.update({
+                    'system.ammo.bullet': systemData.ammo.bullet - 1,
+                });
+                return true;
+            } else if (ammoType === 'none') {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
 }
 
 export async function onDamageFromChat(event) {
-  event.preventDefault();
-  const a = event.currentTarget;
+    event.preventDefault();
+    const a = event.currentTarget;
 
-  const button = a.closest("button");
-  const actor = button.dataset.actorId
-    ? game.actors.get(button.dataset.actorId)
-    : null;
-  const item = button.dataset.itemId
-    ? actor.items.get(button.dataset.itemId)
-    : null;
+    const button = a.closest('button');
+    const actor = button.dataset.actorId ? game.actors.get(button.dataset.actorId) : null;
+    const item = button.dataset.itemId ? actor.items.get(button.dataset.itemId) : null;
 
-  _rollDamage(a, actor, item);
+    _rollDamage(a, actor, item);
 }
 
 export async function onDamageFromSheet(event) {
-  event.preventDefault();
-  const a = event.currentTarget;
+    event.preventDefault();
+    const a = event.currentTarget;
 
-  // Find closest <li> element containing a "data-item-id" attribute
-  const li = a.closest("li");
-  const actor = this.actor;
-  const item = li.dataset.itemId
-    ? this.actor.items.get(li.dataset.itemId)
-    : null;
+    // Find closest <li> element containing a "data-item-id" attribute
+    const li = a.closest('li');
+    const actor = this.actor;
+    const item = li.dataset.itemId ? this.actor.items.get(li.dataset.itemId) : null;
 
-  _rollDamage(a, actor, item);
+    _rollDamage(a, actor, item);
 }
 
 async function _rollDamage(a, actor, item) {
-  const systemData = actor.system;
-  const itemData = item.system;
+    const systemData = actor.system;
+    const itemData = item.system;
 
-  const speaker = ChatMessage.getSpeaker({ actor: actor });
-  const rollMode = game.settings.get("core", "rollMode");
+    const speaker = ChatMessage.getSpeaker({ actor: actor });
+    const rollMode = game.settings.get('core', 'rollMode');
 
-  // Return if the weapon is broken
-  if (
-    item.type === "weapon" &&
-    itemData.broken === true &&
-    game.settings.get("knave2e", "enforceBreaks")
-  ) {
-    Dialog.prompt({
-      title: `${game.i18n.localize("KNAVE2E.Item")} ${game.i18n.localize(
-        "KNAVE2E.Broken"
-      )}`,
-      content: `${item.name} ${game.i18n.localize("KNAVE2E.IsBroken")}!`,
-      label: "OK",
-      callback: (html) => {
+    // Return if the weapon is broken
+    if (item.type === 'weapon' && itemData.broken === true && game.settings.get('knave2e', 'enforceBreaks')) {
+        Dialog.prompt({
+            title: `${game.i18n.localize('KNAVE2E.Item')} ${game.i18n.localize('KNAVE2E.Broken')}`,
+            content: `${item.name} ${game.i18n.localize('KNAVE2E.IsBroken')}!`,
+            label: 'OK',
+            callback: (html) => {
+                return;
+            },
+        });
+
         return;
-      },
+    }
+
+    // Change rollFlavor depending on Damage/Direct/Power
+    let rollFlavor = `${game.i18n.localize('KNAVE2E.DamageRoll')} ${game.i18n.localize('KNAVE2E.With')} ${item.name}`;
+
+    let formula = `@amount@size+@bonus`;
+    let amount = itemData.damageDiceAmount;
+    const size = itemData.damageDiceSize;
+    const bonus = itemData.damageDiceBonus;
+
+    // Only characters can power attack
+    if (actor.type === 'character') {
+        if (event.shiftKey === false) {
+            const powerAttack = await damageDialog();
+            if (powerAttack) {
+                amount = amount * 2; // double dice on power attack
+
+                if (game.settings.get('knave2e', 'enforceBreaks')) {
+                    item.update({
+                        // power attacks break item
+                        'system.broken': true,
+                    });
+                    rollFlavor =
+                        rollFlavor +
+                        `. ${game.i18n.localize('KNAVE2E.PowerAttack')} ${game.i18n.localize('KNAVE2E.Breaks')} ${
+                            item.name
+                        }!`;
+                }
+            }
+        }
+    }
+
+    if (a.dataset.action === 'direct') {
+        formula = `3*(@amount@size+@bonus)`;
+    }
+
+    const r = await new Roll(formula, {
+        amount: amount,
+        size: size,
+        bonus: bonus,
     });
 
-    return;
-  }
-
-  // Change rollFlavor depending on Damage/Direct/Power
-  let rollFlavor = `${game.i18n.localize(
-    "KNAVE2E.DamageRoll"
-  )} ${game.i18n.localize("KNAVE2E.With")} ${item.name}`;
-
-  let formula = `@amount@size+@bonus`;
-  let amount = itemData.damageDiceAmount;
-  const size = itemData.damageDiceSize;
-  const bonus = itemData.damageDiceBonus;
-
-  // Only characters can power attack
-  if (actor.type === "character") {
-    if (event.shiftKey === false) {
-      const powerAttack = await damageDialog();
-      if (powerAttack) {
-        amount = amount * 2; // double dice on power attack
-
-        if (game.settings.get("knave2e", "enforceBreaks")) {
-          item.update({
-            // power attacks break item
-            "system.broken": true,
-          });
-          rollFlavor =
-            rollFlavor +
-            `. ${game.i18n.localize(
-              "KNAVE2E.PowerAttack"
-            )} ${game.i18n.localize("KNAVE2E.Breaks")} ${item.name}!`;
-        }
-      }
-    }
-  }
-
-  if (a.dataset.action === "direct") {
-    formula = `3*(@amount@size+@bonus)`;
-  }
-
-  const r = await new Roll(formula, {
-    amount: amount,
-    size: size,
-    bonus: bonus,
-  });
-
-  r.toMessage({
-    speaker: speaker,
-    flavor: rollFlavor,
-    rollMode: rollMode,
-  });
+    r.toMessage({
+        speaker: speaker,
+        flavor: rollFlavor,
+        rollMode: rollMode,
+    });
 }
 
 export async function onLinkFromChat(event) {
-  event.preventDefault();
-  const a = event.currentTarget;
+    event.preventDefault();
+    const a = event.currentTarget;
 
-  const link = a.closest("a");
-  const item = game.items.get(link.dataset.id);
+    const link = a.closest('a');
+    const item = game.items.get(link.dataset.id);
 
-  ChatMessage.create({
-    flavor: `${item.name}`,
-    content: `${item.system.description}`,
-  });
+    ChatMessage.create({
+        flavor: `${item.name}`,
+        content: `${item.system.description}`,
+    });
 }

--- a/module/knave2e.mjs
+++ b/module/knave2e.mjs
@@ -1,341 +1,330 @@
-import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
+import { preloadHandlebarsTemplates } from './helpers/templates.mjs';
 
 // Import DataModel classes.
 
-import * as DataModels from "./data/_module.mjs";
-import {
-  Knave2eActor,
-  Knave2eItem,
-  Knave2eChatMessage,
-} from "./documents/_module.mjs";
-import { Knave2eActorSheet, Knave2eItemSheet } from "./sheets/_module.mjs";
-import { SYSTEM } from "./config/system.mjs";
+import * as DataModels from './data/_module.mjs';
+import { Knave2eActor, Knave2eItem, Knave2eChatMessage } from './documents/_module.mjs';
+import { Knave2eActorSheet, Knave2eItemSheet } from './sheets/_module.mjs';
+import { SYSTEM } from './config/system.mjs';
 
 /* -------------------------------------------- */
 /*  Init Hook                                   */
 /* -------------------------------------------- */
 
-Hooks.on("init", () => {
-  CONFIG.Actor.dataModels.character = DataModels.Knave2eCharacter;
-  CONFIG.Actor.dataModels.recruit = DataModels.Knave2eRecruit;
-  CONFIG.Actor.dataModels.monster = DataModels.Knave2eMonster;
-  CONFIG.Actor.dataModels.vehicle = DataModels.Knave2eVehicle;
-  CONFIG.Item.dataModels.weapon = DataModels.Knave2eWeapon;
-  CONFIG.Item.dataModels.spellbook = DataModels.Knave2eSpellbook;
-  CONFIG.Item.dataModels.lightSource = DataModels.Knave2eLightSource;
-  CONFIG.Item.dataModels.equipment = DataModels.Knave2eEquipment;
-  CONFIG.Item.dataModels.armor = DataModels.Knave2eArmor;
-  CONFIG.Item.dataModels.monsterAttack = DataModels.Knave2eMonsterAttack;
+Hooks.on('init', () => {
+    CONFIG.Actor.dataModels.character = DataModels.Knave2eCharacter;
+    CONFIG.Actor.dataModels.recruit = DataModels.Knave2eRecruit;
+    CONFIG.Actor.dataModels.monster = DataModels.Knave2eMonster;
+    CONFIG.Actor.dataModels.vehicle = DataModels.Knave2eVehicle;
+    CONFIG.Item.dataModels.weapon = DataModels.Knave2eWeapon;
+    CONFIG.Item.dataModels.spellbook = DataModels.Knave2eSpellbook;
+    CONFIG.Item.dataModels.lightSource = DataModels.Knave2eLightSource;
+    CONFIG.Item.dataModels.equipment = DataModels.Knave2eEquipment;
+    CONFIG.Item.dataModels.armor = DataModels.Knave2eArmor;
+    CONFIG.Item.dataModels.monsterAttack = DataModels.Knave2eMonsterAttack;
 });
 
-Hooks.once("init", () => {
-  CONFIG.SYSTEM = SYSTEM;
+Hooks.once('init', () => {
+    CONFIG.SYSTEM = SYSTEM;
 });
 
-Hooks.once("i18nInit", function () {
-  // Apply localizations
-  const toLocalize = [
-    "ABILITIES",
-    "AMMO",
-    "ARMOR",
-    "COIN",
-    "EQUIPMENT",
-    "SPELLBOOK",
-    "WEAPON",
-  ];
-  for (let c of toLocalize) {
-    const conf = foundry.utils.getProperty(SYSTEM, c);
-    for (let [k, v] of Object.entries(conf)) {
-      if (v.label) v.label = game.i18n.localize(v.label);
-      if (v.abbreviation) v.abbreviation = game.i18n.localize(v.abbreviation);
-      if (typeof v === "string") conf[k] = game.i18n.localize(v);
+Hooks.once('i18nInit', function () {
+    // Apply localizations
+    const toLocalize = ['ABILITIES', 'AMMO', 'ARMOR', 'COIN', 'EQUIPMENT', 'SPELLBOOK', 'WEAPON'];
+    for (let c of toLocalize) {
+        const conf = foundry.utils.getProperty(SYSTEM, c);
+        for (let [k, v] of Object.entries(conf)) {
+            if (v.label) v.label = game.i18n.localize(v.label);
+            if (v.abbreviation) v.abbreviation = game.i18n.localize(v.abbreviation);
+            if (typeof v === 'string') conf[k] = game.i18n.localize(v);
+        }
     }
-  }
 });
 
-Hooks.once("init", function () {
-  // Add utility classes to the global game object so that they're more easily
-  // accessible in global contexts.
-  game.knave2e = {
-    Knave2eActor,
-    Knave2eItem,
-    Knave2eChatMessage,
-    rollItemMacro,
-  };
+Hooks.once('init', function () {
+    // Add utility classes to the global game object so that they're more easily
+    // accessible in global contexts.
+    game.knave2e = {
+        Knave2eActor,
+        Knave2eItem,
+        Knave2eChatMessage,
+        rollItemMacro,
+    };
 
-  // Set globals from game settings (TODO: localize)
+    // Set globals from game settings (TODO: localize)
 
-  // Automatic AC/AP
-  game.settings.register("knave2e", "automaticArmor", {
-    name: "Automate AC and AP",
-    hint: "Derive AP from equipped armor and AC from 11 + AP. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic AC/AP
+    game.settings.register('knave2e', 'automaticArmor', {
+        name: 'Automate AC and AP',
+        hint: 'Derive AP from equipped armor and AC from 11 + AP. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Blessings
-  game.settings.register("knave2e", "automaticBlessings", {
-    name: "Automate Blessings",
-    hint: "Derive maximum active blessings from CHA. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Blessings
+    game.settings.register('knave2e', 'automaticBlessings', {
+        name: 'Automate Blessings',
+        hint: 'Derive maximum active blessings from CHA. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Companions
-  game.settings.register("knave2e", "automaticCompanions", {
-    name: "Automate Companions",
-    hint: "Derive maximum lifetime companions from CHA. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Companions
+    game.settings.register('knave2e', 'automaticCompanions', {
+        name: 'Automate Companions',
+        hint: 'Derive maximum lifetime companions from CHA. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Levels
-  game.settings.register("knave2e", "automaticLevel", {
-    name: "Automate Level",
-    hint: "Derive current level from XP. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Levels
+    game.settings.register('knave2e', 'automaticLevel', {
+        name: 'Automate Level',
+        hint: 'Derive current level from XP. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Lights
-  game.settings.register("knave2e", "automaticLight", {
-    name: "Automate Lights",
-    hint: "Derive light radius from active light sources. Disable for increased performance on slower hardware. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Lights
+    game.settings.register('knave2e', 'automaticLight', {
+        name: 'Automate Lights',
+        hint: 'Derive light radius from active light sources. Disable for increased performance on slower hardware. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Recruits
-  game.settings.register("knave2e", "automaticRecruits", {
-    name: "Automate Recruits",
-    hint: "Derive monthly cost, morale, rarity, and max slots/spells for recruited followers. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Recruits
+    game.settings.register('knave2e', 'automaticRecruits', {
+        name: 'Automate Recruits',
+        hint: 'Derive monthly cost, morale, rarity, and max slots/spells for recruited followers. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Slots
-  game.settings.register("knave2e", "automaticSlots", {
-    name: "Automate Slots",
-    hint: "Derive maximum item slots from 10 + CON. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Slots
+    game.settings.register('knave2e', 'automaticSlots', {
+        name: 'Automate Slots',
+        hint: 'Derive maximum item slots from 10 + CON. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Spells
-  game.settings.register("knave2e", "automaticSpells", {
-    name: "Automate Spells",
-    hint: "Derive maximum spells from INT. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Spells
+    game.settings.register('knave2e', 'automaticSpells', {
+        name: 'Automate Spells',
+        hint: 'Derive maximum spells from INT. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Vision for Characters
-  game.settings.register("knave2e", "automaticVision", {
-    name: "Automate Vision",
-    hint: "Enables Vision when creating a new Character. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Vision for Characters
+    game.settings.register('knave2e', 'automaticVision', {
+        name: 'Automate Vision',
+        hint: 'Enables Vision when creating a new Character. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Automatic Wounds
-  game.settings.register("knave2e", "automaticWounds", {
-    name: "Automate Wounds",
-    hint: "Derive maximum wounds from 10 + CON. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Automatic Wounds
+    game.settings.register('knave2e', 'automaticWounds', {
+        name: 'Automate Wounds',
+        hint: 'Derive maximum wounds from 10 + CON. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Armor Restriction
-  game.settings.register("knave2e", "enforceArmor", {
-    name: "Enforce Unique Armor Types",
-    hint: "Prevents equipping multiple armor pieces of the same type (e.g. two Helmets). Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Armor Restriction
+    game.settings.register('knave2e', 'enforceArmor', {
+        name: 'Enforce Unique Armor Types',
+        hint: 'Prevents equipping multiple armor pieces of the same type (e.g. two Helmets). Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Maximum Blessings
-  game.settings.register("knave2e", "enforceBlessings", {
-    name: "Enforce Active Blessings",
-    hint: "Prevents activating more blessings than a PC's CHA. Defaults to True.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Maximum Blessings
+    game.settings.register('knave2e', 'enforceBlessings', {
+        name: 'Enforce Active Blessings',
+        hint: "Prevents activating more blessings than a PC's CHA. Defaults to True.",
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Maximum Companions
-  game.settings.register("knave2e", "enforceCompanions", {
-    name: "Enforce Lifetime Companions",
-    hint: "Prevents recording more lifetime companions than a PC's CHA. Defaults to True.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Maximum Companions
+    game.settings.register('knave2e', 'enforceCompanions', {
+        name: 'Enforce Lifetime Companions',
+        hint: "Prevents recording more lifetime companions than a PC's CHA. Defaults to True.",
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Item Dropping
-  game.settings.register("knave2e", "enforceDrop", {
-    name: "Enforce Dropping Items",
-    hint: 'Mark items as "Dropped" after receiving wounds. Defaults to TRUE.',
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Item Dropping
+    game.settings.register('knave2e', 'enforceDrop', {
+        name: 'Enforce Dropping Items',
+        hint: 'Mark items as "Dropped" after receiving wounds. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Integer Slots
-  game.settings.register("knave2e", "enforceIntegerSlots", {
-    name: "Enforce Integer Slots",
-    hint: "Fractional slots rounded up to the nearest integer. Defaults to TRUE.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Integer Slots
+    game.settings.register('knave2e', 'enforceIntegerSlots', {
+        name: 'Enforce Integer Slots',
+        hint: 'Fractional slots rounded up to the nearest integer. Defaults to TRUE.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Spellbook Casting
-  game.settings.register("knave2e", "enforceSpells", {
-    name: "Enforce Casting Spellbooks",
-    hint: 'Mark spellbooks as "Cast" after use. Defaults to True.',
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Spellbook Casting
+    game.settings.register('knave2e', 'enforceSpells', {
+        name: 'Enforce Casting Spellbooks',
+        hint: 'Mark spellbooks as "Cast" after use. Defaults to True.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Weapon Breaking
-  game.settings.register("knave2e", "enforceBreaks", {
-    name: "Enforce Breaking Weapons",
-    hint: 'Mark weapons as "Broken" after a power attack or natural 1. Defaults to True.',
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Weapon Breaking
+    game.settings.register('knave2e', 'enforceBreaks', {
+        name: 'Enforce Breaking Weapons',
+        hint: 'Mark weapons as "Broken" after a power attack or natural 1. Defaults to True.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // Enforce Ammunition Usage
-  game.settings.register("knave2e", "enforceAmmo", {
-    name: "Enforce Ammunition Usage",
-    hint: "Ranged weapons consume ammunition, and will not fire if the PC has no ammunition of the required type. Defaults to True.",
-    scope: "world",
-    config: true,
-    type: Boolean,
-    default: true,
-    requiresReload: true,
-  });
+    // Enforce Ammunition Usage
+    game.settings.register('knave2e', 'enforceAmmo', {
+        name: 'Enforce Ammunition Usage',
+        hint: 'Ranged weapons consume ammunition, and will not fire if the PC has no ammunition of the required type. Defaults to True.',
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: true,
+        requiresReload: true,
+    });
 
-  // XP to Level 2
-  game.settings.register("knave2e", "baseLevelXP", {
-    name: "Override XP to Level 2",
-    hint: "Override XP required to reach level 2. Each subsequent level requires approximately twice as much XP. Defaults to 2000.",
-    scope: "world",
-    config: true,
-    type: Number,
-    default: 2000,
-    requiresReload: true,
-  });
+    // XP to Level 2
+    game.settings.register('knave2e', 'baseLevelXP', {
+        name: 'Override XP to Level 2',
+        hint: 'Override XP required to reach level 2. Each subsequent level requires approximately twice as much XP. Defaults to 2000.',
+        scope: 'world',
+        config: true,
+        type: Number,
+        default: 2000,
+        requiresReload: true,
+    });
 
-  // Arrows Per Slot
-  game.settings.register("knave2e", "arrowsPerSlot", {
-    name: "Override Arrows Per Slot",
-    hint: "Set to 0 to disable automatic slot tracking for arrows. Defaults to 20.",
-    scope: "world",
-    config: true,
-    type: Number,
-    default: 20,
-    requiresReload: true,
-  });
+    // Arrows Per Slot
+    game.settings.register('knave2e', 'arrowsPerSlot', {
+        name: 'Override Arrows Per Slot',
+        hint: 'Set to 0 to disable automatic slot tracking for arrows. Defaults to 20.',
+        scope: 'world',
+        config: true,
+        type: Number,
+        default: 20,
+        requiresReload: true,
+    });
 
-  // Sling Bullets Per Slot
-  game.settings.register("knave2e", "slingBulletsPerSlot", {
-    name: "Override Sling Bullets Per Slot",
-    hint: "Set to 0 to disable automatic slot tracking for sling bullets. Defaults to 5.",
-    scope: "world",
-    config: true,
-    type: Number,
-    default: 5,
-    requiresReload: true,
-  });
+    // Sling Bullets Per Slot
+    game.settings.register('knave2e', 'slingBulletsPerSlot', {
+        name: 'Override Sling Bullets Per Slot',
+        hint: 'Set to 0 to disable automatic slot tracking for sling bullets. Defaults to 5.',
+        scope: 'world',
+        config: true,
+        type: Number,
+        default: 5,
+        requiresReload: true,
+    });
 
-  // Coins Per Slot
-  game.settings.register("knave2e", "coinsPerSlot", {
-    name: "Override Coins Per Slot",
-    hint: "Set to 0 to disable automatic slot tracking for coins. Defaults to 500.",
-    scope: "world",
-    config: true,
-    type: Number,
-    default: 500,
-    requiresReload: true,
-  });
+    // Coins Per Slot
+    game.settings.register('knave2e', 'coinsPerSlot', {
+        name: 'Override Coins Per Slot',
+        hint: 'Set to 0 to disable automatic slot tracking for coins. Defaults to 500.',
+        scope: 'world',
+        config: true,
+        type: Number,
+        default: 500,
+        requiresReload: true,
+    });
 
-  // XP Per Level
-  game.settings.register("knave2e", "xpPerLevel", {
-    name: "Override XP required per Level",
-    hint: "Modify the required XP for each level. Advanced users can add additional levels beyond 10. Defaults to the Knave 2E Leveling Rules.",
-    scope: "world",
-    config: true,
-    type: String,
-    default: "{\"1\":{\"xp\":0,\"label\":\"Wretch\"},\"2\":{\"xp\":2000,\"label\":\"Lowlife\"},\"3\":{\"xp\":4000,\"label\":\"Hoodlum\"},\"4\":{\"xp\":8000,\"label\":\"Fool\"},\"5\":{\"xp\":16000,\"label\":\"Dastard\"},\"6\":{\"xp\":32000,\"label\":\"Cad\"},\"7\":{\"xp\":64000,\"label\":\"Gadabout\"},\"8\":{\"xp\":125000,\"label\":\"Rogue\"},\"9\":{\"xp\":250000,\"label\":\"Jack\"},\"10\":{\"xp\":500000,\"label\":\"Knave\"}}",
-    requiresReload: true,
-  });
+    // XP Per Level
+    game.settings.register('knave2e', 'xpPerLevel', {
+        name: 'Override XP required per Level',
+        hint: 'Modify the required XP for each level. Advanced users can add additional levels beyond 10. Defaults to the Knave 2E Leveling Rules.',
+        scope: 'world',
+        config: true,
+        type: String,
+        default:
+            '{"1":{"xp":0,"label":"Wretch"},"2":{"xp":2000,"label":"Lowlife"},"3":{"xp":4000,"label":"Hoodlum"},"4":{"xp":8000,"label":"Fool"},"5":{"xp":16000,"label":"Dastard"},"6":{"xp":32000,"label":"Cad"},"7":{"xp":64000,"label":"Gadabout"},"8":{"xp":125000,"label":"Rogue"},"9":{"xp":250000,"label":"Jack"},"10":{"xp":500000,"label":"Knave"}}',
+        requiresReload: true,
+    });
 
-  CONFIG.Combat.initiative = {
-    formula: "1d20 + @abilities.charisma.value",
-    decimals: 2,
-  };
+    CONFIG.Combat.initiative = {
+        formula: '1d20 + @abilities.charisma.value',
+        decimals: 2,
+    };
 
-  // Define custom Document classes
-  CONFIG.Actor.documentClass = Knave2eActor;
-  CONFIG.Item.documentClass = Knave2eItem;
-  CONFIG.ChatMessage.documentClass = Knave2eChatMessage;
+    // Define custom Document classes
+    CONFIG.Actor.documentClass = Knave2eActor;
+    CONFIG.Item.documentClass = Knave2eItem;
+    CONFIG.ChatMessage.documentClass = Knave2eChatMessage;
 
-  // Register sheet application classes
-  Actors.unregisterSheet("core", ActorSheet);
-  Actors.registerSheet("knave2e", Knave2eActorSheet, { makeDefault: true });
-  Items.unregisterSheet("core", ItemSheet);
-  Items.registerSheet("knave2e", Knave2eItemSheet, { makeDefault: true });
+    // Register sheet application classes
+    Actors.unregisterSheet('core', ActorSheet);
+    Actors.registerSheet('knave2e', Knave2eActorSheet, { makeDefault: true });
+    Items.unregisterSheet('core', ItemSheet);
+    Items.registerSheet('knave2e', Knave2eItemSheet, { makeDefault: true });
 
-  // Preload Handlebars templates.
-  return preloadHandlebarsTemplates();
+    // Preload Handlebars templates.
+    return preloadHandlebarsTemplates();
 });
 
 /* -------------------------------------------- */
@@ -343,27 +332,27 @@ Hooks.once("init", function () {
 /* -------------------------------------------- */
 
 // If you need to add Handlebars helpers, here are a few useful examples:
-Handlebars.registerHelper("concat", function () {
-  var outStr = "";
-  for (var arg in arguments) {
-    if (typeof arguments[arg] != "object") {
-      outStr += arguments[arg];
+Handlebars.registerHelper('concat', function () {
+    var outStr = '';
+    for (var arg in arguments) {
+        if (typeof arguments[arg] != 'object') {
+            outStr += arguments[arg];
+        }
     }
-  }
-  return outStr;
+    return outStr;
 });
 
-Handlebars.registerHelper("toLowerCase", function (str) {
-  return str.toLowerCase();
+Handlebars.registerHelper('toLowerCase', function (str) {
+    return str.toLowerCase();
 });
 
 /* -------------------------------------------- */
 /*  Ready Hook                                  */
 /* -------------------------------------------- */
 
-Hooks.once("ready", function () {
-  // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
-  Hooks.on("hotbarDrop", (bar, data, slot) => createItemMacro(data, slot));
+Hooks.once('ready', function () {
+    // Wait to register hotbar drop hook on ready so that modules could register earlier if they want to
+    Hooks.on('hotbarDrop', (bar, data, slot) => createItemMacro(data, slot));
 });
 
 /* -------------------------------------------- */
@@ -378,32 +367,28 @@ Hooks.once("ready", function () {
  * @returns {Promise}
  */
 async function createItemMacro(data, slot) {
-  // First, determine if this is a valid owned item.
-  if (data.type !== "Item") return;
-  if (!data.uuid.includes("Actor.") && !data.uuid.includes("Token.")) {
-    return ui.notifications.warn(
-      "You can only create macro buttons for owned Items"
-    );
-  }
-  // If it is, retrieve it based on the uuid.
-  const item = await Item.fromDropData(data);
+    // First, determine if this is a valid owned item.
+    if (data.type !== 'Item') return;
+    if (!data.uuid.includes('Actor.') && !data.uuid.includes('Token.')) {
+        return ui.notifications.warn('You can only create macro buttons for owned Items');
+    }
+    // If it is, retrieve it based on the uuid.
+    const item = await Item.fromDropData(data);
 
-  // Create the macro command using the uuid.
-  const command = `game.knave2e.rollItemMacro("${data.uuid}");`;
-  let macro = game.macros.find(
-    (m) => m.name === item.name && m.command === command
-  );
-  if (!macro) {
-    macro = await Macro.create({
-      name: item.name,
-      type: "script",
-      img: item.img,
-      command: command,
-      flags: { "knave2e.itemMacro": true },
-    });
-  }
-  game.user.assignHotbarMacro(macro, slot);
-  return false;
+    // Create the macro command using the uuid.
+    const command = `game.knave2e.rollItemMacro("${data.uuid}");`;
+    let macro = game.macros.find((m) => m.name === item.name && m.command === command);
+    if (!macro) {
+        macro = await Macro.create({
+            name: item.name,
+            type: 'script',
+            img: item.img,
+            command: command,
+            flags: { 'knave2e.itemMacro': true },
+        });
+    }
+    game.user.assignHotbarMacro(macro, slot);
+    return false;
 }
 
 /**
@@ -412,22 +397,22 @@ async function createItemMacro(data, slot) {
  * @param {string} itemUuid
  */
 function rollItemMacro(itemUuid) {
-  // Reconstruct the drop data so that we can load the item.
-  const dropData = {
-    type: "Item",
-    uuid: itemUuid,
-  };
-  // Load the item from the uuid.
-  Item.fromDropData(dropData).then((item) => {
-    // Determine if the item loaded and if it's an owned item.
-    if (!item || !item.parent) {
-      const itemName = item?.name ?? itemUuid;
-      return ui.notifications.warn(
-        `Could not find item ${itemName}. You may need to delete and recreate this macro.`
-      );
-    }
+    // Reconstruct the drop data so that we can load the item.
+    const dropData = {
+        type: 'Item',
+        uuid: itemUuid,
+    };
+    // Load the item from the uuid.
+    Item.fromDropData(dropData).then((item) => {
+        // Determine if the item loaded and if it's an owned item.
+        if (!item || !item.parent) {
+            const itemName = item?.name ?? itemUuid;
+            return ui.notifications.warn(
+                `Could not find item ${itemName}. You may need to delete and recreate this macro.`
+            );
+        }
 
-    // Trigger the item roll
-    item.roll();
-  });
+        // Trigger the item roll
+        item.roll();
+    });
 }

--- a/templates/item/item-equipment-sheet.hbs
+++ b/templates/item/item-equipment-sheet.hbs
@@ -65,17 +65,6 @@
       <div class="item-body-aside">
         <div class="flexrow flex-group-left flex-between">
           <div class="resource-label aside">{{localize
-              "KNAVE2E.QuantityPerSlot"
-            }}</div>
-          <input
-            type="text"
-            name="system.quantityPerSlot"
-            value="{{system.quantityPerSlot}}"
-            data-dtype="Number"
-          />
-        </div>
-        <div class="flexrow flex-group-left flex-between">
-          <div class="resource-label aside">{{localize
               "KNAVE2E.Quantity"
             }}</div>
           <input

--- a/templates/item/item-lightSource-sheet.hbs
+++ b/templates/item/item-lightSource-sheet.hbs
@@ -65,18 +65,6 @@
       <div class="item-body-aside">
         <div class="flexrow flex-group-left flex-between">
           <div class="resource-label aside">{{localize
-              "KNAVE2E.QuantityPerSlot"
-            }}</div>
-          <input
-            type="text"
-            name="system.quantityPerSlot"
-            value="{{system.quantityPerSlot}}"
-            data-dtype="Number"
-          />
-        </div>
-        <hr class="separator" />
-        <div class="flexrow flex-group-left flex-between">
-          <div class="resource-label aside">{{localize
               "KNAVE2E.DimRadius"
             }}</div>
           <input


### PR DESCRIPTION
Mostly a 0.5.0 hotfix:

- Fixed wound value on character sheets capping at 10, regardless of max wounds
- Fixed character attack rolls multiplying the STR or WIS modifier by 10
- Fixed '# Per Slot' input field still appearing on Equipment & Light Source item sheets
- Added HP overflow for character tokens, so that HP bar updates that go into the negative values also subtract from wounds.